### PR TITLE
Show proxy output

### DIFF
--- a/.github/workflows/proxy-ci.yaml
+++ b/.github/workflows/proxy-ci.yaml
@@ -27,10 +27,10 @@ jobs:
         run: curl -L -s --output swio https://github.com/seedwing-io/seedwing-policy/releases/download/v0.1.0-nightly.b1769553/swio-linux-amd64 && chmod 755 swio
 
       - name: Install proxy
-        run: curl -L -s https://github.com/seedwing-io/seedwing-proxy/releases/download/v0.1.0-alpha.2/seedwing-proxy-x86_64-unknown-linux-gnu.tar.gz | tar xzf - seedwing-proxy
+        run: curl -L -s https://github.com/seedwing-io/seedwing-proxy/releases/download/v0.1.0-alpha.3/seedwing-proxy-x86_64-unknown-linux-gnu.tar.gz | tar xzf - seedwing-proxy
 
       - name: Run proxy in background
-        run: ./seedwing-proxy -c config/proxy.toml &
+        run: ./seedwing-proxy -c config/proxy.toml >/tmp/proxy.log 2>&1 &
 
       - name: Run policy server in background
         run: ./swio serve -p policies &
@@ -41,7 +41,14 @@ jobs:
           for x in {1..20}; do sleep 1; date; if curl -s -o /dev/null http://localhost:8080; then echo "swio is up"; break; fi; done
 
       - name: Build java app
+        continue-on-error: true
         run: |
           mkdir -p ~/.m2
           cp config/maven-settings.xml ~/.m2/settings.xml
           ./mvnw compile
+
+      - name: Log proxy output and verify failure
+        run: |
+          cat /tmp/proxy.log
+          echo "Rejected requests:"
+          grep -e '"GET .*" 422 ' /tmp/proxy.log


### PR DESCRIPTION
This PR changes the proxy workflow so that a failed build denotes workflow success, i.e. the proxy did its job.

@lulf I'm confused by the fact that the proxy rejects more GAV requests than the cli returns to the Java CI workflow.

The proxy rejects these:
```
[2023-03-22T17:01:20Z INFO  actix_web::middleware::logger] 10.1.1.98 "GET /m2/org/apache/maven/maven/3.6.3/maven-3.6.3.pom HTTP/1.1" 422 4515 "-" "Apache-Maven/3.8.6 (Java 17.0.6; Linux 5.15.0-1034-azure)" 0.346837
[2023-03-22T17:01:57Z INFO  actix_web::middleware::logger] 10.1.1.98 "GET /m2/com/google/guava/guava/31.1-jre/guava-31.1-jre.pom HTTP/1.1" 422 7465 "-" "Apache-Maven/3.8.6 (Java 17.0.6; Linux 5.15.0-1034-azure)" 0.340992
[2023-03-22T17:03:15Z INFO  actix_web::middleware::logger] 10.1.1.98 "GET /m2/org/yaml/snakeyaml/1.33/snakeyaml-1.33.pom HTTP/1.1" 422 2753 "-" "Apache-Maven/3.8.6 (Java 17.0.6; Linux 5.15.0-1034-azure)" 0.358176
[2023-03-22T17:03:23Z INFO  actix_web::middleware::logger] 10.1.1.98 "GET /m2/org/jdom/jdom/1.1.3/jdom-1.1.3.pom HTTP/1.1" 422 1541 "-" "Apache-Maven/3.8.6 (Java 17.0.6; Linux 5.15.0-1034-azure)" 0.350820
[2023-03-22T17:03:31Z INFO  actix_web::middleware::logger] 10.1.1.98 "GET /m2/org/apache/maven/maven/3.5.0/maven-3.5.0.pom HTTP/1.1" 422 4515 "-" "Apache-Maven/3.8.6 (Java 17.0.6; Linux 5.15.0-1034-azure)" 0.347482
```
And the cli only seems to complain about `pkg:maven/io.vertx/vertx-web`. That's weird, right? The patterns are slightly different, but I would expect that both would report the same misbehavers, or at least one's rejects should be a subset of the other. Can you help me explain that?